### PR TITLE
feat(emul-20): hero image

### DIFF
--- a/src/components/atoms/RichText/richText.module.css
+++ b/src/components/atoms/RichText/richText.module.css
@@ -23,3 +23,14 @@
 .richText * ~ h3 {
   margin-top: var(--space-xl);
 }
+
+.richText img {
+  margin: var(--space-margin-overflow);
+  max-width: calc(100% + calc(var(--space-band-horizontal) * 2));
+}
+
+@media only screen and (min-width: 750px) {
+  .richText img {
+    max-width: calc(100% + calc(var(--space-band-horizontal) / 1.5));
+  }
+}

--- a/src/components/base/base.css
+++ b/src/components/base/base.css
@@ -19,6 +19,8 @@
   --space-4xl: 15rem;
   --space-band-vertical: clamp(var(--space-xl), 7vw, var(--space-3xl));
   --space-band-horizontal: clamp(var(--space-l), 4.44vw, var(--space-2xl));
+  --space-margin-overflow: 0 calc(var(--space-band-horizontal) * -1);
+  --space-margin-overflow-inset: 0 var(--space-band-horizontal);
 
   /* Typography */
   --font-scale-5: 3rem;
@@ -35,6 +37,10 @@
 
 @media only screen and (min-width: 750px) {
   :root {
+    /* Spacing */
+    --space-margin-overflow: 0 calc(var(--space-band-horizontal) * -0.33);
+    --space-margin-overflow-inset: var(--space-margin-overflow);
+
     /* Typography */
     --font-scale-5: 4rem;
     --font-scale-4: 3.3rem;
@@ -135,15 +141,9 @@ blockquote {
   line-height: 1.5;
   letter-spacing: -0.24px;
   color: var(--c-blue-gray);
-  margin: 0 0 0 var(--space-band-horizontal);
+  margin: var(--space-margin-overflow-inset);
   padding: 0;
   max-width: 45ch;
-}
-
-@media only screen and (min-width: 750px) {
-  blockquote {
-    margin-left: calc(var(--space-band-horizontal) * -0.33);
-  }
 }
 
 /* Highlighted Content */

--- a/src/components/data/blog.tsx
+++ b/src/components/data/blog.tsx
@@ -76,6 +76,9 @@ export const blogText = (
       advanced, site-building has grown more accessible through “codeless”
       development within the Drupal UI.
     </p>
+    <p>
+      <img src="https://picsum.photos/900/506" alt="Example Image" />
+    </p>
     <h2>
       No-Code Software Plays a Critical Role in Modern Website Development
     </h2>

--- a/src/components/molecules/PageMeta/PageMeta.stories.tsx
+++ b/src/components/molecules/PageMeta/PageMeta.stories.tsx
@@ -33,7 +33,13 @@ export default {
       },
       defaultValue: 'January 27, 2021',
     },
-    withImage: {
+    withAuthorImage: {
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: true,
+    },
+    withHeroImage: {
       control: {
         type: 'boolean',
       },
@@ -43,21 +49,29 @@ export default {
 }
 
 type PageMetaStoryProps = PageMetaProps &
-  AuthorInfoProps & { withImage: boolean }
+  AuthorInfoProps & {
+    withAuthorImage: boolean
+    withHeroImage: boolean
+  }
 
 export const pageMeta: Story<PageMetaStoryProps> = ({
   heading,
   text,
   name,
   date,
-  withImage,
+  withAuthorImage,
+  withHeroImage,
 }) => {
   let image = null
-  if (withImage === true) {
+  let heroImage = null
+  if (withAuthorImage === true) {
     image = <img src="https://picsum.photos/90" alt="example image" />
   }
+  if (withHeroImage === true) {
+    heroImage = <img src="https://picsum.photos/1200/720" alt="example image" />
+  }
   return (
-    <PageMeta heading={heading} text={text}>
+    <PageMeta heading={heading} text={text} heroImage={heroImage}>
       <AuthorInfo image={image} name={name} date={date} />
     </PageMeta>
   )

--- a/src/components/molecules/PageMeta/PageMeta.tsx
+++ b/src/components/molecules/PageMeta/PageMeta.tsx
@@ -5,12 +5,19 @@ import styles from './pageMeta.module.css'
 export type PageMetaProps = {
   heading?: string
   text?: ReactNode
+  heroImage?: ReactNode
 }
 
-export const PageMeta: FC<PageMetaProps> = ({ heading, text, children }) => (
+export const PageMeta: FC<PageMetaProps> = ({
+  heading,
+  children,
+  text,
+  heroImage,
+}) => (
   <div className={styles.pageMeta}>
     {heading && <h1 className={styles.pageMetaHeading}>{heading}</h1>}
     {children && <div className={styles.pageMetaContent}>{children}</div>}
     {text && <div className={styles.pageMetaText}>{text}</div>}
+    {heroImage && <div className={styles.pageMetaHeroImage}>{heroImage}</div>}
   </div>
 )

--- a/src/components/molecules/PageMeta/pageMeta.module.css
+++ b/src/components/molecules/PageMeta/pageMeta.module.css
@@ -20,3 +20,7 @@
 .pageMetaText *:last-child {
   margin-bottom: 0;
 }
+
+.pageMetaHeroImage {
+  margin: var(--space-margin-overflow);
+}

--- a/src/components/pages/blog.stories.tsx
+++ b/src/components/pages/blog.stories.tsx
@@ -54,6 +54,12 @@ export default {
       },
       defaultValue: true,
     },
+    withHeroImage: {
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: true,
+    },
   },
 }
 
@@ -63,6 +69,7 @@ type HomepageProps = WithSidebarProps &
     pageTitle: string
     pageSubtitle: string
     withAuthorImage: boolean
+    withHeroImage: boolean
   }
 
 export const IndividualBlog: Story<HomepageProps> = ({
@@ -70,17 +77,22 @@ export const IndividualBlog: Story<HomepageProps> = ({
   pageSubtitle,
   location,
   withAuthorImage,
+  withHeroImage,
   name,
   date,
 }) => {
   let image = null
+  let heroImage = null
   if (withAuthorImage === true) {
     image = <img src="https://picsum.photos/90" alt="example image" />
+  }
+  if (withHeroImage === true) {
+    heroImage = <img src="https://picsum.photos/1200/720" alt="example image" />
   }
   return (
     <WithSidebar location={location} navItems={navItems} sidebar={<Signup />}>
       <BackLink url="#" text="view all blog posts" />
-      <PageMeta heading={pageTitle} text={pageSubtitle}>
+      <PageMeta heading={pageTitle} text={pageSubtitle} heroImage={heroImage}>
         <AuthorInfo image={image} name={name} date={date} />
       </PageMeta>
       <RichText>{blogText}</RichText>

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -33,7 +33,13 @@ class BlogPostTemplate extends React.Component<PageProps> {
       <WithSidebar location={this.props.location} sidebar={<Signup />}>
         <SEO title={post.title} />
         <BackLink url="/blog" text="view all blog posts" />
-        <PageMeta heading={post.title} text={pageMetaText}>
+        <PageMeta
+          heading={post.title}
+          text={pageMetaText}
+          heroImage={
+            <img src={post.heroImage.file.url} alt={post.heroImage.title} />
+          }
+        >
           <AuthorInfo
             image={
               <img src={post.author.photo.file.url} alt={post.author.name} />
@@ -102,6 +108,12 @@ export const pageQuery = graphql`
       body {
         childMarkdownRemark {
           html
+        }
+      }
+      heroImage {
+        title
+        file {
+          url
         }
       }
     }


### PR DESCRIPTION
## [EMUL-20: Hero Image/Embedded Image](https://fourkitchens.atlassian.net/browse/EMUL-20)

**This PR does the following:**

- Adds a Hero Image to the PageMeta component
- Styles embed images (inside RichText)

<!--
### Local Testing setup (if you haven't done it yet):

- [ ] Clone this repo and/or checkout this branch
- [ ] run `yarn` to install dependencies
- [ ] Copy `.env.example` to `.env.development`, and fill in the required credentials.
-->

### Functional Testing:

- [ ] Run `yarn storybook` and verify:
  - [ ] The [PageMeta component](http://localhost:6006/?path=/story/molecules-pagemeta--page-meta) now includes an optional hero image
  - [ ] The [Individual Blog](http://localhost:6006/?path=/story/pages-blogs--individual-blog) has the HeroImage
  - [ ] The Individual Blog also has an image inside the main content that "overflow" the text the same as the hero image
- [ ] Run `yarn develop` and verify [this blog](http://localhost:8000/blog/why-developers-shouldnt-fear-a-no-code-interface) has everything above

<!--
**Notes:**
- Verify the functionality is working with translations.
- Verify other pages are not affected by the branch
-->
