### PR TITLE
Add download file for Research article; List only published articles on blog page

### DIFF
--- a/src/templates/blog.tsx
+++ b/src/templates/blog.tsx
@@ -66,6 +66,7 @@ export const pageQuery = graphql`
       sort: { fields: [publishDate], order: DESC }
       limit: $limit
       skip: $skip
+      filter: { publishToBlog: { eq: true } }
     ) {
       edges {
         node {


### PR DESCRIPTION
**This PR does the following:**
- Adds `static/emulsify-research-playback.pdf` for an article
- Fixes `/blog` so it only lists articles marked to be published.

### Functional Testing:
- Run `yarn develop`
- [x] Visit http://localhost:8000/blog/researching-the-state-of-emulsify and confirm you can download Emulsify Research Playback v1.1
- [x] Visit http://localhost:8000/blog/ and confirm you do not see an article titled "This article should not appear on the site."
