### PR TITLE
fix: homepage blog filter

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -203,6 +203,7 @@ export const query = graphql`
     allContentfulBlog(
       sort: { fields: [publishDate], order: DESC }
       limit: $limit
+      filter: { publishToBlog: { eq: true } }
     ) {
       edges {
         node {


### PR DESCRIPTION
**This PR does the following:**
- Filters the blog post on the homepage so it only shows approved articles.