### PR TITLE
feat: Add RSS back to the site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "react-player": "^2.12.0",
         "remark": "^14.0.2",
         "remark-html": "^15.0.2",
+        "rss": "^1.2.2",
         "super-react-gist": "^1.1.1",
         "tailwindcss": "^3.2.1"
       },
@@ -6990,6 +6991,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==",
+      "dependencies": {
+        "mime-db": "~1.25.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -8231,6 +8251,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==",
+      "dependencies": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9436,6 +9465,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -14343,6 +14377,19 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w=="
+    },
+    "mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==",
+      "requires": {
+        "mime-db": "~1.25.0"
+      }
+    },
     "mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -15175,6 +15222,15 @@
         "glob": "^7.1.3"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -16000,6 +16056,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-player": "^2.12.0",
     "remark": "^14.0.2",
     "remark-html": "^15.0.2",
+    "rss": "^1.2.2",
     "super-react-gist": "^1.1.1",
     "tailwindcss": "^3.2.1"
   },

--- a/public/rss-planet-drupal.xml
+++ b/public/rss-planet-drupal.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title><![CDATA[Emulsify Blog RSS Feed]]></title>
+        <description><![CDATA[Emulsify Blog RSS Feed]]></description>
+        <link>localhost:3000</link>
+        <generator>RSS for Node</generator>
+        <lastBuildDate>Wed, 21 Jun 2023 02:46:14 GMT</lastBuildDate>
+        <atom:link href="localhost:3000/rss.xml" rel="self" type="application/rss+xml"/>
+        <pubDate>Wed, 21 Jun 2023 02:46:14 GMT</pubDate>
+        <item>
+            <title><![CDATA[Introducing the Emulsify UI Kit Beta: The Open Source Tool Set for Design Systems]]></title>
+            <description><![CDATA[The Emulsify UI Kit beta is an open source tool set that combines storybook, configuration, and other resources to make it easy to create design systems. It includes a Figma file and an open source code repository, and allows designers and front-end engineers to collaborate closely to create custom design systems for Drupal and other websites.]]></description>
+            <link>https://emulsify.info/blog/introducing-the-emulsify-ui-kit-beta-the-open-source-tool-set-for-design</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/introducing-the-emulsify-ui-kit-beta-the-open-source-tool-set-for-design</guid>
+            <pubDate>Wed, 07 Jun 2023 07:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[An Emulsify Drupal site is up for a Webby! Go vote!]]></title>
+            <description><![CDATA[The Wu Tsai Institute website, built with Emulsify, has been nominated for a Webby Award in the School/University and Best Mobile Visual Design Aesthetic categories! The website was built using Drupal and uses Emulsify for theming. The Webby Awards are determined by a panel of judges and popular vote, so everyone is encouraged to vote for the website on the Webby Awards website.]]></description>
+            <link>https://emulsify.info/blog/an-emulsify-drupal-site-is-up-for-a-webby-go-vote</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/an-emulsify-drupal-site-is-up-for-a-webby-go-vote</guid>
+            <pubDate>Wed, 05 Apr 2023 07:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Adding a JS library to an Emulsify Component in Drupal]]></title>
+            <description><![CDATA[Adding a JavaScript library to an Emulsify component may seem daunting if you're new to the process, but it's not as complicated as it may seem. In this guide, we'll show you how to add a JavaScript library to an Emulsify component step-by-step, using the Swiper library as an example.]]></description>
+            <link>https://emulsify.info/blog/adding-a-js-library-to-an-emulsify-component-in-drupal</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/adding-a-js-library-to-an-emulsify-component-in-drupal</guid>
+            <pubDate>Thu, 30 Mar 2023 07:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Specbee teaches how Emulsify Twig makes it easy to write BEM CSS class names]]></title>
+            <description><![CDATA[The BEM (Block, Element, Modifier) methodology is a widely used naming convention for CSS classes that is popular because of the ease of use it offers. Find out how Emulsify Twig makes it easy in Drupal.]]></description>
+            <link>https://emulsify.info/blog/specbee-teaches-how-emulsify-twig-makes-it-easy-to-write-bem-css-class-names</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/specbee-teaches-how-emulsify-twig-makes-it-easy-to-write-bem-css-class-names</guid>
+            <pubDate>Thu, 10 Nov 2022 08:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Researching the state of Emulsify]]></title>
+            <description><![CDATA[The Emulsify project has grown a lot since it first launched in 2016. We have thousands of people using it across Drupal and WordPress and a vibrant community of contributors. To celebrate, we are working with you, the community, to create a roadmap for Emulsify that will guide us into the future. ]]></description>
+            <link>https://emulsify.info/blog/researching-the-state-of-emulsify</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/researching-the-state-of-emulsify</guid>
+            <pubDate>Thu, 08 Sep 2022 07:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Frontend & Figma Magic, Building a Connected UI Kit for Emulsify]]></title>
+            <description><![CDATA[Website production has always progressed while navigating a broad divide: the line separating visual design and frontend development. Now, through Emulsify harnessing Figma’s design tokens plugin, design and development teams can enjoy an automated communication connection.]]></description>
+            <link>https://emulsify.info/blog/frontend-and-figma-magic-building-a-connected-ui-kit-for-emulsify</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/frontend-and-figma-magic-building-a-connected-ui-kit-for-emulsify</guid>
+            <pubDate>Sat, 01 Oct 2022 07:00:00 GMT</pubDate>
+        </item>
+    </channel>
+</rss>

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title><![CDATA[Emulsify Blog RSS Feed]]></title>
+        <description><![CDATA[Emulsify Blog RSS Feed]]></description>
+        <link>localhost:3000</link>
+        <generator>RSS for Node</generator>
+        <lastBuildDate>Wed, 21 Jun 2023 02:46:14 GMT</lastBuildDate>
+        <atom:link href="localhost:3000/rss.xml" rel="self" type="application/rss+xml"/>
+        <pubDate>Wed, 21 Jun 2023 02:46:14 GMT</pubDate>
+        <item>
+            <title><![CDATA[Introducing the Emulsify UI Kit Beta: The Open Source Tool Set for Design Systems]]></title>
+            <description><![CDATA[The Emulsify UI Kit beta is an open source tool set that combines storybook, configuration, and other resources to make it easy to create design systems. It includes a Figma file and an open source code repository, and allows designers and front-end engineers to collaborate closely to create custom design systems for Drupal and other websites.]]></description>
+            <link>https://emulsify.info/blog/introducing-the-emulsify-ui-kit-beta-the-open-source-tool-set-for-design</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/introducing-the-emulsify-ui-kit-beta-the-open-source-tool-set-for-design</guid>
+            <pubDate>Wed, 07 Jun 2023 07:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[An Emulsify Drupal site is up for a Webby! Go vote!]]></title>
+            <description><![CDATA[The Wu Tsai Institute website, built with Emulsify, has been nominated for a Webby Award in the School/University and Best Mobile Visual Design Aesthetic categories! The website was built using Drupal and uses Emulsify for theming. The Webby Awards are determined by a panel of judges and popular vote, so everyone is encouraged to vote for the website on the Webby Awards website.]]></description>
+            <link>https://emulsify.info/blog/an-emulsify-drupal-site-is-up-for-a-webby-go-vote</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/an-emulsify-drupal-site-is-up-for-a-webby-go-vote</guid>
+            <pubDate>Wed, 05 Apr 2023 07:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Adding a JS library to an Emulsify Component in Drupal]]></title>
+            <description><![CDATA[Adding a JavaScript library to an Emulsify component may seem daunting if you're new to the process, but it's not as complicated as it may seem. In this guide, we'll show you how to add a JavaScript library to an Emulsify component step-by-step, using the Swiper library as an example.]]></description>
+            <link>https://emulsify.info/blog/adding-a-js-library-to-an-emulsify-component-in-drupal</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/adding-a-js-library-to-an-emulsify-component-in-drupal</guid>
+            <pubDate>Thu, 30 Mar 2023 07:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Introducing the design tokens file format (from Schema 2022)]]></title>
+            <description><![CDATA[The Design Tokens Community Group (DTCG) is defining a standard design tokens file format, which aims to make sharing design tokens between different tools seamless.]]></description>
+            <link>https://emulsify.info/blog/introducing-the-design-tokens-file-format-from-schema-2022</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/introducing-the-design-tokens-file-format-from-schema-2022</guid>
+            <pubDate>Mon, 21 Nov 2022 08:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Specbee teaches how Emulsify Twig makes it easy to write BEM CSS class names]]></title>
+            <description><![CDATA[The BEM (Block, Element, Modifier) methodology is a widely used naming convention for CSS classes that is popular because of the ease of use it offers. Find out how Emulsify Twig makes it easy in Drupal.]]></description>
+            <link>https://emulsify.info/blog/specbee-teaches-how-emulsify-twig-makes-it-easy-to-write-bem-css-class-names</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/specbee-teaches-how-emulsify-twig-makes-it-easy-to-write-bem-css-class-names</guid>
+            <pubDate>Thu, 10 Nov 2022 08:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Researching the state of Emulsify]]></title>
+            <description><![CDATA[The Emulsify project has grown a lot since it first launched in 2016. We have thousands of people using it across Drupal and WordPress and a vibrant community of contributors. To celebrate, we are working with you, the community, to create a roadmap for Emulsify that will guide us into the future. ]]></description>
+            <link>https://emulsify.info/blog/researching-the-state-of-emulsify</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/researching-the-state-of-emulsify</guid>
+            <pubDate>Thu, 08 Sep 2022 07:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Frontend & Figma Magic, Building a Connected UI Kit for Emulsify]]></title>
+            <description><![CDATA[Website production has always progressed while navigating a broad divide: the line separating visual design and frontend development. Now, through Emulsify harnessing Figma’s design tokens plugin, design and development teams can enjoy an automated communication connection.]]></description>
+            <link>https://emulsify.info/blog/frontend-and-figma-magic-building-a-connected-ui-kit-for-emulsify</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/frontend-and-figma-magic-building-a-connected-ui-kit-for-emulsify</guid>
+            <pubDate>Sat, 01 Oct 2022 07:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Get ready to learn all about Emulsify with our fresh blog]]></title>
+            <description><![CDATA[We want to communicate what is going on in the world of design systems, Drupal themes, WordPress themes, design tokens, and Emulsify with you.]]></description>
+            <link>https://emulsify.info/blog/get-ready-for-to-learn-all-about-emulsify-with-our-fresh-blog</link>
+            <guid isPermaLink="true">https://emulsify.info/blog/get-ready-for-to-learn-all-about-emulsify-with-our-fresh-blog</guid>
+            <pubDate>Tue, 30 Aug 2022 07:00:00 GMT</pubDate>
+        </item>
+    </channel>
+</rss>

--- a/src/pages/rss.js
+++ b/src/pages/rss.js
@@ -1,0 +1,21 @@
+import Head from 'next/head'
+import generateRssFeed from '../utils/generateRSSFeed'
+
+export async function getStaticProps() {
+  const posts = await generateRssFeed()
+  return { props: { posts } }
+}
+
+export default function RSS({ posts }) {
+  return (
+    <>
+      <Head>
+        <title>Emulsify RSS</title>
+        <meta property="og:title" content="Emulsify RSS" key="title" />
+      </Head>
+      <div>
+        <h1>RSS placeholder</h1>
+      </div>
+    </>
+  )
+}

--- a/src/utils/generateRSSFeed.js
+++ b/src/utils/generateRSSFeed.js
@@ -1,0 +1,66 @@
+import fs from 'fs'
+import RSS from 'rss'
+import getBlogPosts from './getContentful'
+import eventFormatter from './eventFormatter'
+
+export default async function generateRssFeed() {
+  const siteUrl = 'localhost:3000'
+  const posts = await getBlogPosts()
+
+  const feedOptions = {
+    title: 'Emulsify Blog RSS Feed',
+    site_url: siteUrl,
+    feed_url: `${siteUrl}/rss.xml`,
+    pubDate: new Date(),
+  }
+
+  const feed = new RSS(feedOptions)
+
+  posts
+    .filter((post) => post.fields.publishToBlog === true)
+    // eslint-disable-next-line array-callback-return
+    .map((post) => {
+      feed.item({
+        title: post.fields.title,
+        description: post.fields.description,
+        url: `https://emulsify.info/blog/${post.fields.slug}`,
+        date: eventFormatter(post.fields.publishDate),
+      })
+    })
+
+  fs.writeFileSync('./public/rss.xml', feed.xml({ indent: true }))
+
+  const drupalFeedOptions = {
+    title: 'Emulsify Blog RSS Feed for Planet Drupal',
+    site_url: siteUrl,
+    feed_url: `${siteUrl}/rss.xml`,
+    pubDate: new Date(),
+  }
+
+  const drupalFeed = new RSS(drupalFeedOptions)
+
+  posts
+    .filter((post) => post.fields.publishToBlog === true)
+    .filter((post) => {
+      if (post.fields.category) {
+        return post.fields.category[0].fields.title === 'Drupal'
+      }
+      return null
+    })
+    .map((post) => {
+      drupalFeed.item({
+        title: post.fields.title,
+        description: post.fields.description,
+        url: `https://emulsify.info/blog/${post.fields.slug}`,
+        date: eventFormatter(post.fields.publishDate),
+      })
+      return null
+    })
+
+  fs.writeFileSync(
+    './public/rss-planet-drupal.xml',
+    drupalFeed.xml({ indent: true })
+  )
+
+  return posts
+}


### PR DESCRIPTION
## Add RSS back to the site

**This PR does the following:**

- Adds back two RSS feeds—an all blog articles feed and a Drupal-only feed for Planet Drupal.

###
- [ ] To successfully run `npm install` you will need to define FONTAWESOME_NPM_AUTH_TOKEN. The value for this can be found in the Four Kitchens 1Password shared folder.

### Functional Testing 
- [ ] Confirm that the main RSS feed exists at https://deploy-preview-112--emulsify-website.netlify.app/rss.xml
- [ ] Confirm that the Planet Drupal RSS feed exists at https://deploy-preview-112--emulsify-website.netlify.app/rss-planet-drupal.xml
- [ ] Confirm that the Planet Drupal feed has fewer items than the main feed.

Closes #111

