### PR TITLE
docs: link fixes

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -29,7 +29,7 @@ export function Footer() {
           <h2 className="text-xl font-bold ">
             Emulsify is a product of{' '}
             <Link
-              href="https://fourkitchens.com"
+              href="https://www.fourkitchens.com"
               className="border-b border-solid border-emulsifyBlue-400  text-emulsifyBlue-100 transition-colors hover:border-emulsifyBlue-100"
             >
               Four Kitchens
@@ -41,7 +41,7 @@ export function Footer() {
             system, the Web Chefs have you covered.
           </p>
           <Link
-            href="https://fourkitchens.com/"
+            href="https://www.fourkitchens.com/"
             className={classNames(
               'mt-4 inline-block rounded px-4 py-2 transition-colors',
               'bg-emulsifyBlue-700',

--- a/src/pages/docs/emulsify-drupal/index.md
+++ b/src/pages/docs/emulsify-drupal/index.md
@@ -9,7 +9,7 @@ description: No description. ''
 ### Requirements
 
 1. [Node (we recommend NVM)](https://github.com/nvm-sh/nvm)
-2. [Emulsify CLI](https://docs.emulsify.info/supporting-projects/emulsify-cli) (Not strictly recommended, but all docs will assume its use)
+2. [Emulsify CLI](/docs/supporting-projects/emulsify-cli) (Not strictly recommended, but all docs will assume its use)
 
 ### Picking a version
 

--- a/src/pages/docs/resources/help-and-support/index.md
+++ b/src/pages/docs/resources/help-and-support/index.md
@@ -4,7 +4,7 @@ pageTitle: Help and Support
 description: Support resources for Emulsify Design System
 ---
 
-Emulsify is a free, open source project built and maintained by [Four Kitchens](https://fourkitchens.com). We welcome community contributions and support requests (via issues) on [Github](https://github.com/emulsify-ds).
+Emulsify is a free, open source project built and maintained by [Four Kitchens](www.kitchens.com). We welcome community contributions and support requests (via issues) on [Github](https://github.com/emulsify-ds).
 
 ## Support resources
 


### PR DESCRIPTION
**This PR does the following:**

- Fixes the bad link in #122
- Updates Four Kitchens urls to include the 'www'.

How to review:
- Visit https://deploy-preview-123--emulsify-website.netlify.app/docs/emulsify-drupal
- Click on "2. Emulsify CLI" and confirm that the page loads.
- In the footer, confirm that the Four Kitchens text link and the "Get in Touch" button both link to "https://www.fourkitchens.com". Note the WWW should be there.
